### PR TITLE
Fix panic in debug profile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn load_mining_competition_records(map: &mut BTreeMap<Bytes, Capacity>) {
 fn foundation_reserve(target: u64) -> IssuedCell {
     let dummy = Spec {
         timestamp: 0,
-        compact_target: "0x1".to_string(),
+        compact_target: "0x20ffffff".to_string(),
         message: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
         epoch_length: 1000,
         allocate: vec![],


### PR DESCRIPTION
When calculating foundation reserve, the compact target 0x1 leads to
difficulty 0, which causes panic in debug profile.

This commit uses 0x20ffffff, which is converted from difficulty 0x1.